### PR TITLE
Migrate to Pythonic resource system

### DIFF
--- a/jaffle/__init__.py
+++ b/jaffle/__init__.py
@@ -1,10 +1,9 @@
 from dagster import Definitions, load_assets_from_package_module
 
 from jaffle import assets
+from jaffle.duckpond import DuckPondIOManager
 
-from jaffle.duckpond import DuckPondIOManager, DuckDB
-
-DUCKDB_LOCAL_CONFIG="""
+DUCKDB_LOCAL_CONFIG = """
 set s3_access_key_id='test';
 set s3_secret_access_key='test';
 set s3_endpoint='localhost:4566';
@@ -14,5 +13,7 @@ set s3_url_style='path';
 
 defs = Definitions(
     assets=load_assets_from_package_module(assets),
-    resources={"io_manager":  DuckPondIOManager("datalake", DuckDB(DUCKDB_LOCAL_CONFIG))}
+    resources={
+        "io_manager": DuckPondIOManager(bucket_name="datalake", duckdb_options=DUCKDB_LOCAL_CONFIG)
+    },
 )

--- a/jaffle/assets/__init__.py
+++ b/jaffle/assets/__init__.py
@@ -1,6 +1,7 @@
-from dagster import asset
-from jaffle.duckpond import SQL
 import pandas as pd
+from dagster import OpExecutionContext, asset
+
+from jaffle.duckpond import SQL, DuckPondIOManager
 
 
 @asset
@@ -31,9 +32,11 @@ def continent_population(population: SQL) -> SQL:
 
 
 @asset
-def print_continent_population(context, continent_population: SQL):
-    context.log.info(f"Final asset:")
-    context.log.info(context.resources.io_manager.duckdb.query(continent_population))
+def print_continent_population(
+    context: OpExecutionContext, io_manager: DuckPondIOManager, continent_population: SQL
+):
+    context.log.info("Final asset:")
+    context.log.info(io_manager.duckdb.query(continent_population))
 
 
 @asset
@@ -161,9 +164,10 @@ select * from final
 
 
 @asset
-def preview_all(context, customers: SQL, orders: SQL):
-    duckdb = context.resources.io_manager.duckdb
-    context.log.info(f"Customers:")
-    context.log.info(duckdb.query(customers))
-    context.log.info(f"Orders:")
-    context.log.info(duckdb.query(orders))
+def preview_all(
+    context: OpExecutionContext, io_manager: DuckPondIOManager, customers: SQL, orders: SQL
+):
+    context.log.info("Customers:")
+    context.log.info(io_manager.duckdb.query(customers))
+    context.log.info("Orders:")
+    context.log.info(io_manager.duckdb.query(orders))

--- a/jaffle_tests/test_assets.py
+++ b/jaffle_tests/test_assets.py
@@ -1,4 +1,4 @@
-from jaffle.assets import population, continent_population
+from jaffle.assets import continent_population, population
 from jaffle.duckpond import DuckDB
 
 


### PR DESCRIPTION
## Summary

Migrates to using the Pythonic resource system, cutting over `DuckPondIOManager` to be a `ConfigurableIOManager` and accessing resources via params rather than the context.

## Test Plan

Ran locally, ensure everything works.